### PR TITLE
zulu-jdk: move files to designated packages

### DIFF
--- a/recipes-devtools/zulu-ezdk-arm-hflt.bb
+++ b/recipes-devtools/zulu-ezdk-arm-hflt.bb
@@ -43,3 +43,17 @@ PROVIDES += "virtual/java"
 
 DEPENDS = "alsa-lib libxi libxrender libxtst"
 
+FILES_${PN}-doc = " \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*/client/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*/jli/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/man/ \
+	"
+
+FILES_${PN}-dev = " \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/src.zip \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/demo/ \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/sample/ \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/include/ \
+	"

--- a/recipes-devtools/zulu-ezdk-arm-sflt.bb
+++ b/recipes-devtools/zulu-ezdk-arm-sflt.bb
@@ -43,3 +43,17 @@ PROVIDES += "virtual/java"
 
 DEPENDS = "alsa-lib libxi libxrender libxtst"
 
+FILES_${PN}-doc = " \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*/client/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/jre/lib/*/jli/*.diz \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/man/ \
+	"
+
+FILES_${PN}-dev = " \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/src.zip \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/demo/ \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/sample/ \
+	${datadir}/ezdk-${PV}_${PV_UPDATE}/include/ \
+	"

--- a/recipes-devtools/zulu-ezdk-x86-64.bb
+++ b/recipes-devtools/zulu-ezdk-x86-64.bb
@@ -43,3 +43,17 @@ PROVIDES += "virtual/java"
 
 DEPENDS = "alsa-lib libxi libxrender libxtst"
 
+FILES_${PN}-doc = " \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/jre/lib/*/*.diz \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/jre/lib/*.diz \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/jre/lib/*/client/*.diz \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/jre/lib/*/jli/*.diz \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/man/ \
+	"
+
+FILES_${PN}-dev = " \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/src.zip \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/demo/ \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/sample/ \
+	${datadir}/zulu-${PV}_${PV_UPDATE}/include/ \
+	"


### PR DESCRIPTION
The current zulu-jdk package includes many big files that are not
required to run java-programs on target devices. This patch avoids
that zulu-jdk acquires too much space on the target device.

Signed-off-by: Sven Ebenfeld <sven.ebenfeld@gmail.com>