### PR TITLE
layer.conf: add LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "zulujava"
 BBFILE_PATTERN_zulujava := "^${LAYERDIR}/"
 BBFILE_PRIORITY_zulujava = "6"
 
-
+LAYERSERIES_COMPAT_zulujava = "rocko sumo thud"


### PR DESCRIPTION
From the Yocto Project Reference Manual:

> Using the LAYERSERIES_COMPAT variable allows the layer maintainer to indicate which combinations of the layer and OE-Core can be expected to work.

Explicit compatibility with rocko, sumo and thud.